### PR TITLE
Support Python 3.7

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,6 +25,7 @@ This guide based on the one in [factory_girl_rails v4.8.0][source]. Thanks Thoug
 
 1. Test your change:
    1. `tox`
+      1. If you're having trouble getting all the right Python versions installed, I recommend [pyenv][pyenv]. Here's how I [set it up on OS X][python-osx].
    1. Each Python version should apply terraform and output a random number of cars from 0-9.
       (This apply is a no-op: it only collects and outputs fake data.)
 
@@ -65,6 +66,8 @@ Like for pull requests, remember that we don't get paid so there's no SLA. We'll
 [home]: https://operatingops.org
 [homebrew]: https://brew.sh
 [pr]: https://help.github.com/articles/creating-a-pull-request/
+[pyenv]: https://github.com/pyenv/pyenv
+[python-osx]: https://operatingops.org/2018/02/04/python-on-mac-one-of-the-good-ways/
 [rebase]: https://help.github.com/articles/about-git-rebase/
 [source]: https://github.com/thoughtbot/factory_girl_rails/blob/v4.8.0/CONTRIBUTING.md
 [style]: https://github.com/operatingops/simple_style/blob/v0.1.1/SIMPLE_STYLE.md

--- a/README.rst
+++ b/README.rst
@@ -15,6 +15,8 @@ code.
 
 The wrapped function must expect its first positional argument to be a dictionary of the query data.
 
+See the `contributing guide`_ for instructions on developing and running tests.
+
 Example Usage
 =============
 
@@ -80,5 +82,6 @@ Example Usage
 
 
 .. _external program protocol: https://www.terraform.io/docs/providers/external/data_source.html#external-program-protocol
+.. _contributing guide: https://github.com/operatingops/terraform_external_data/blob/master/CONTRIBUTING.md
 .. _venv: https://docs.python.org/3/library/venv.html
 .. _virtualenv: https://virtualenv.pypa.io/en/stable/

--- a/setup.py
+++ b/setup.py
@@ -20,5 +20,5 @@ setup(
     name='terraform_external_data',
     packages=['terraform_external_data'],
     url='https://github.com/operatingops/terraform_external_data',
-    version='0.0.4'
+    version='0.0.5'
 )

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,7 @@ setup(
     author_email='adam@operatingops.org',
     author='Adam Burns',
     classifiers=[
+        "License :: OSI Approved :: MIT License",
         "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7"

--- a/setup.py
+++ b/setup.py
@@ -5,14 +5,14 @@ def readme():
         return f.read()
 
 setup(
-    name='terraform_external_data',
-    version='0.0.4',
-    author='Adam Burns',
     author_email='adam@operatingops.org',
+    author='Adam Burns',
     description="Provides a decorator that implements terraform's external program protocol for data sources.",
+    extras_require={'test': ['tox==3.5.2']},
+    install_requires=['future==0.16.0'],
     long_description=readme(),
+    name='terraform_external_data',
     packages=['terraform_external_data'],
     url='https://github.com/operatingops/terraform_external_data',
-    install_requires=['future==0.16.0'],
-    extras_require={'test': ['tox==3.5.2']}
+    version='0.0.4'
 )

--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,11 @@ def readme():
 setup(
     author_email='adam@operatingops.org',
     author='Adam Burns',
+    classifiers=[
+        "Programming Language :: Python :: 2.7",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7"
+    ],
     description="Provides a decorator that implements terraform's external program protocol for data sources.",
     extras_require={'test': ['tox==3.5.2']},
     install_requires=['future==0.16.0'],

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py36
+envlist = py27,py36,py37
 
 [testenv]
 deps = pylint


### PR DESCRIPTION
Turns out the code is already compatible with 3.7 (no surprise). This expands the test suite to cover that version. I temporarily added a 3.7-only feature to the code and confirmed that tox fails in 2.7 and 3.6 but passes in 3.7.

This also alpha-sorts the args to `setup()` and makes some small documentation improvements related to components I was working on.

Closes #8.