### PR TITLE
Update readme to terraform 0.12 syntax

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -77,7 +77,7 @@ Example Usage
       # Reference the data like any terraform var. This example uses an
       # output so it doesn't modify infrastructure.
       output "cars_count" {
-        value = "${data.external.cars_count.result.cars}"
+        value = data.external.cars_count.result.cars
       }
 
 

--- a/setup.py
+++ b/setup.py
@@ -20,5 +20,5 @@ setup(
     name='terraform_external_data',
     packages=['terraform_external_data'],
     url='https://github.com/operatingops/terraform_external_data',
-    version='0.1.0'
+    version='0.1.1'
 )


### PR DESCRIPTION
This is a companion to #13. When I was updating the code I forgot to update the tf snippet in the readme. This is a non-functional change, but I bumped the version so I can re-upload to PyPI and ensure the docs there are up to date.