### PR TITLE
Remove support for Python 2.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,7 @@ This guide based on the one in [factory_girl_rails v4.8.0][source]. Thanks Thoug
 1. Set up your environment:
    1. Install terraform. It is available in [Homebew][homebrew] and [directly from HashiCorp][hashi-downloads].
    1. `terraform init test/terraform`
-   1. `python3 venv ~/path/to/venv`
+   1. `python venv ~/path/to/venv`
    1. `source ~/path/to/venv/bin/activate`
    1. `pip install -e .[test]`
 

--- a/README.rst
+++ b/README.rst
@@ -20,12 +20,12 @@ See the `contributing guide`_ for instructions on developing and running tests.
 Example Usage
 =============
 
-1. As always, create and activate a venv_ (Python 3) or virtualenv_ (Python 2).
+1. As always, create and activate a venv_.
 
    .. code:: bash
 
-      python3 -m venv env3
-      source env3/bin/activate
+      python -m venv env
+      source env/bin/activate
 
 2. Install `terraform_external_data` in the env.
 

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
         "Programming Language :: Python :: 3.7"
     ],
     description="Provides a decorator that implements terraform's external program protocol for data sources.",
-    extras_require={'test': ['tox==3.12.1']},
+    extras_require={'test': ['tox >=3.13, <3.14']},
     long_description=readme(),
     name='terraform_external_data',
     packages=['terraform_external_data'],

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,6 @@ setup(
     ],
     description="Provides a decorator that implements terraform's external program protocol for data sources.",
     extras_require={'test': ['tox==3.12.1']},
-    install_requires=['future>=0.16.0'],
     long_description=readme(),
     name='terraform_external_data',
     packages=['terraform_external_data'],

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,6 @@ setup(
     author='Adam Burns',
     classifiers=[
         "License :: OSI Approved :: MIT License",
-        "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7"
     ],
@@ -20,5 +19,5 @@ setup(
     name='terraform_external_data',
     packages=['terraform_external_data'],
     url='https://github.com/operatingops/terraform_external_data',
-    version='0.1.1'
+    version='1.0.0'
 )

--- a/terraform_external_data/terraform_external_data.py
+++ b/terraform_external_data/terraform_external_data.py
@@ -3,11 +3,9 @@ Provides a decorator that implements terraform's external program protocol for d
 https://www.terraform.io/docs/providers/external/data_source.html
 """
 
-from __future__ import print_function
 import json
 import sys
 from functools import wraps
-from past.builtins import basestring
 
 def error(message):
     """
@@ -24,7 +22,7 @@ def validate(data):
     if not isinstance(data, dict):
         error('Data must be a dictionary.')
     for value in data.values():
-        if not isinstance(value, basestring):
+        if not isinstance(value, str):
             error('Values must be strings.')
 
 
@@ -43,7 +41,7 @@ def terraform_external_data(function):
             result = function(query, *args, **kwargs)
         except Exception as e:
             # Terraform wants one-line errors so we catch all exceptions and trim down to just the message (no trace).
-            error('{}: {}'.format(type(e).__name__, e))
+            error(f'{type(e).__name__}: {e}')
         validate(result)
         sys.stdout.write(json.dumps(result))
     return wrapper

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py36,py37
+envlist = py36,py37
 
 [testenv]
 deps = pylint


### PR DESCRIPTION
Fixes #7 

This includes adding Python 3 features, like f-strings, that aren't
technically necessary but that were only excluded before for Python 2
support.

This is backwards-incompatible, so it comes with a major version bump.

Given the length of time this project has been live with no interface
changes, it makes sense to go to 1.0.0 rather than staying at 0.x.y.

This also bumps the version of tox because it's a convenient time to
do that.