### PR TITLE
Update contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,4 +81,4 @@ Like for pull requests, remember that we don't get paid so there's no SLA. We'll
 [python-osx]: https://operatingops.org/2018/02/04/python-on-mac-one-of-the-good-ways/
 [rebase]: https://help.github.com/articles/about-git-rebase/
 [source]: https://github.com/thoughtbot/factory_girl_rails/blob/v4.8.0/CONTRIBUTING.md
-[style]: https://github.com/operatingops/simple_style/blob/v0.1.1/SIMPLE_STYLE.md
+[style]: https://github.com/operatingops/simple_style/blob/v0.2.0/SIMPLE_STYLE.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,8 +1,17 @@
 # Contributing
 
-This project follows the [Ubuntu Code of Conduct v2.0][conduct]. Thanks Ubuntu!
-
 This guide based on the one in [factory_girl_rails v4.8.0][source]. Thanks Thoughtbot!
+
+## Conduct
+
+We'd love for you to contribute, and we want you to be you while you do it. This project follows a few rules that we hope will make contributing a good experience for everyone. These rules are just a framework; they're here to help you understand how the project works. Each contributor is responsible for their conduct.
+
+* Be professional.
+* The project's maintainers manage the project. You (hopefully!) contribute. Don't try to manage the project or the people working on it unless a current maintainer specifically asks you to.
+* Only use the project to work on the project. Take non-project conversations and activities somewhere else.
+* Contribute your own work. If you use someone else's work:
+  * Make sure it has a non-viral (e.g. no GNU) license that allows you to use it on this project.
+  * Credit them where you use their work (e.g. with a link in a comment).
 
 ## Code
 


### PR DESCRIPTION
The Ubuntu link had gone stale. Includes a bump of the style guide version (minor changes).