### PR TITLE
Terraform 13

### DIFF
--- a/examples/versions.tf
+++ b/examples/versions.tf
@@ -1,4 +1,9 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    external = {
+      source = "hashicorp/external"
+    }
+  }
 }

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,6 @@ commands =
     pylint terraform_external_data
 
 [testenv:terratest]
-deps = pylint
 allowlist_externals = go
 changedir = test/terratest
 setenv =


### PR DESCRIPTION
Fixes #19.

Terraform won't let you use 0.13 on a 0.12 state, so this is a backwards-incompatible change. It turns out that nothing but the version settings changed, so the actual behavior of the decorator works with both versions. This PR just updates the example used by terratest. I also rechecked the external program protocol (link in the readme) and didn't see any differences.

I'm not going to release a new version to PyPI because nothing in the Python changed. It'd be an empty release.