### PR TITLE
Add missing Python 3.8 classifier to setup.py.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,7 @@ setup(
         "License :: OSI Approved :: MIT License",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3 :: Only"
     ],
     description="Provides a decorator that implements terraform's external program protocol for data sources.",
@@ -20,5 +21,5 @@ setup(
     name='terraform_external_data',
     packages=['terraform_external_data'],
     url='https://github.com/operatingops/terraform_external_data',
-    version='1.0.1'
+    version='1.1.0'
 )


### PR DESCRIPTION
Fixes #21 