### PR TITLE
Run terratest for all Python versions.

### DIFF
--- a/azure_pipeline.yaml
+++ b/azure_pipeline.yaml
@@ -89,5 +89,5 @@ jobs:
     # In tox, "py" means, "The current Python version tox is using":
     # https://tox.readthedocs.io/en/latest/example/basic.html#a-simple-tox-ini-default-environments
     # https://docs.microsoft.com/en-us/azure/devops/pipelines/ecosystems/python?view=azure-devops#run-tests-with-tox
-  - pwsh: tox --installpkg $(Pipeline.Workspace)/wheel/terraform_external_data-*-py3-none-any.whl -e py,terratest
+  - pwsh: tox --installpkg $(Pipeline.Workspace)/wheel/terraform_external_data-*-py3-none-any.whl -e py
     displayName: Run tox

--- a/test/terratest/cars_count_test.go
+++ b/test/terratest/cars_count_test.go
@@ -1,13 +1,22 @@
 package test
 
 import (
+	"os/exec"
+	"strings"
 	"testing"
 
+	"github.com/gruntwork-io/terratest/modules/logger"
 	"github.com/gruntwork-io/terratest/modules/terraform"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestTerraformExternalData(t *testing.T) {
+	pythonVersion, error := exec.Command("python", "--version").Output()
+	if error != nil {
+		logger.Log(t, error)
+	}
+	logger.Log(t, strings.TrimSuffix(string(pythonVersion), "\n"))
+
 	t.Parallel()
 	terraformOptions := &terraform.Options{
 		TerraformDir: "../../examples",

--- a/tox.ini
+++ b/tox.ini
@@ -1,15 +1,14 @@
 [tox]
-envlist = terratest, py36, py37, py38
+envlist = py{36,37,38}
 
 [testenv]
+allowlist_externals =
+    cd
+    go
 deps = pylint
-commands =
-    pylint terraform_external_data
-
-[testenv:terratest]
-allowlist_externals = go
-changedir = test/terratest
 setenv =
     HOME = {toxworkdir}
+changedir = test/terratest
 commands =
+    pylint --rcfile=../../.pylintrc terraform_external_data
     go test -count=1


### PR DESCRIPTION
This includes an addition to terratest that logs which version
the 'python' binary points to. Since that's the binary run by
the external data resource in the example, it tells us what
version of Python is running the decorator.

To get tox to run both pylint and terratest when the 'py' env
was set (the pipeline uses this to manage python versions inside
its build servers), both commands had to be put in the default
testenv. Experimentation showed that the generative syntax could
create more testenvs for terratest, but it wouldn't select them
from the current version of Python when the 'py' env was set. It
only does that for the default testenv. See azure_pipelines.yaml
for details on how 'py' is used. This requires a slightly funky
--rcfile flag for pylint, but otherwise works fine.

Before submitting, double-check that:
* [x] You read the [contributing guide][contributing].
* [ ] ~~You increased the version in [setup.py][setup].~~ No changes to the python.
* [ ] ~~The version you chose conforms to [semver][semver].~~ N\A.
* [x] `tox` passes.

Leave this checklist in the description. Check the box for each completed item by replacing `[ ]` with `[x]`.

[contributing]: CONTRIBUTING.md
[semver]: https://semver.org/spec/v2.0.0.html
[setup]: setup.py
